### PR TITLE
add extra info about reconnection

### DIFF
--- a/chapter2.txt
+++ b/chapter2.txt
@@ -55,7 +55,7 @@ ZeroMQ connections are somewhat different from classic TCP connections. The main
 
 * There is no {{zmq_accept}}() method. When a socket is bound to an endpoint it automatically starts accepting connections.
 
-* The network connection itself happens in the background, and ZeroMQ will automatically reconnect if the network connection is broken (e.g., if the peer disappears and then comes back).
+* The network connection itself happens in the background, and ZeroMQ will automatically reconnect (except for PAIR sockets) if the network connection is broken (e.g., if the peer disappears and then comes back).
 
 * Your application code cannot work with these connections directly; they are encapsulated under the socket.
 
@@ -162,7 +162,7 @@ If you are using ZeroMQ for inter-thread communications only (i.e., a multithrea
 
 Underneath the brown paper wrapping of ZeroMQ's socket API lies the world of messaging patterns. If you have a background in enterprise messaging, or know UDP well, these will be vaguely familiar. But to most ZeroMQ newcomers, they are a surprise. We're so used to the TCP paradigm where a socket maps one-to-one to another node.
 
-Let's recap briefly what ZeroMQ does for you. It delivers blobs of data (messages) to nodes, quickly and efficiently. You can map nodes to threads, processes, or nodes. ZeroMQ gives your applications a single socket API to work with, no matter what the actual transport (like in-process, inter-process, TCP, or multicast). It automatically reconnects to peers as they come and go. It queues messages at both sender and receiver, as needed. It limits these queues to guard processes against running out of memory. It handles socket errors. It does all I/O in background threads. It uses lock-free techniques for talking between nodes, so there are never locks, waits, semaphores, or deadlocks.
+Let's recap briefly what ZeroMQ does for you. It delivers blobs of data (messages) to nodes, quickly and efficiently. You can map nodes to threads, processes, or nodes. ZeroMQ gives your applications a single socket API to work with, no matter what the actual transport (like in-process, inter-process, TCP, or multicast). It automatically reconnects (except for PAIR sockets) to peers as they come and go. It queues messages at both sender and receiver, as needed. It limits these queues to guard processes against running out of memory. It handles socket errors. It does all I/O in background threads. It uses lock-free techniques for talking between nodes, so there are never locks, waits, semaphores, or deadlocks.
 
 But cutting through that, it routes and queues messages according to precise recipes called //patterns//. It is these patterns that provide ZeroMQ's intelligence. They encapsulate our hard-earned experience of the best ways to distribute data and work. ZeroMQ's patterns are hard-coded but future versions may allow user-definable patterns.
 


### PR DESCRIPTION
Previously the non-reconnecting behavior of PAIR sockets is only mentioned in section "Node Coordination": "PAIR sockets do not automatically reconnect if the remote node goes away and comes back." This might mislead newcomers if they don't read this section.